### PR TITLE
Fix: change code from open to bz2.open to fix UnicodeDecodeError

### DIFF
--- a/train_baselines.py
+++ b/train_baselines.py
@@ -100,7 +100,7 @@ def main(cfg):
 
     evaluate_dataset(val, dataset_val, cfg.fval, Model, cfg)
 
-    with open(cfg.ftest, 'rt') as f:
+    with bz2.open(cfg.ftest, 'rt') as f: 
         test = json.load(f)
 
     if cfg.debug:


### PR DESCRIPTION
Edit train_baselines.py to fix code error 

When we download [the provided dataset from the author,](https://s3.us-west-1.wasabisys.com/vzhong-public/RoMQA/romqa_data.zip
) the file format is bz2 format in default. 
```
romqa/data/closed/
├── sanity_check.py
├── top_20.dev.json.bz2
├── top_20.test.noanswer.json.bz2
└── top_20.train.json.bz2

romqa/data/open/
├── top_20.dev.json.bz2
├── top_20.test.noanswer.json.bz2
└── top_20.train.json.bz2
```
So changing the `train_baselines.py`, to match cfg.ftest file's default format, bz2, to fix the following error.

```
File "train_baselines.py", line 109, in main
test = json.load(f)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xad in position 10: invalid start byte
```
```

-    with open(cfg.ftest, 'rt') as f:
+    with bz2.open(cfg.ftest, 'rt') as f: 
         test = json.load(f)
```